### PR TITLE
Fix code scanning alert no. 7: Implicit narrowing conversion in compound assignment

### DIFF
--- a/testcore/test/java/hgtest/indexing/ManyToManyIndexerTests.java
+++ b/testcore/test/java/hgtest/indexing/ManyToManyIndexerTests.java
@@ -161,7 +161,7 @@ public class ManyToManyIndexerTests extends HGTestBase
         }
         result.close();
         result = index.scanKeys();
-        int totalValues2 = 0;
+        long totalValues2 = 0;
         while (result.hasNext())
         {
             long forkey = index.count(result.next());


### PR DESCRIPTION
Fixes [https://github.com/rez-trueagi-io/hypergraphdb/security/code-scanning/7](https://github.com/rez-trueagi-io/hypergraphdb/security/code-scanning/7)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of `totalValues2` from `int` to `long` to match the type of `forkey`. This will prevent any implicit narrowing conversion and potential data loss.

**Steps to fix:**
1. Change the type of `totalValues2` from `int` to `long` on line 164.
2. Ensure that any other usage of `totalValues2` is compatible with the new type.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
